### PR TITLE
Implement more robust algorithm for reading ACS circular buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sync.ffs_db
 *.h5
 inf4-test-data.csv
 *.egg-info
+.vscode

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Miniforge is a good choice.
 Next, create the `turbinedaq` conda environment with `conda env create` or
 `mamba env create`.
 Additional useful dev dependencies can be installed with
-`pip install isort black`.
+`pip install isort black pytest`.
 Next, install the `turbinedaq` package in editable mode with
 `pip install -e .`.
 The app can be run by running `turbinedaq` from the command line.

--- a/dev.ipynb
+++ b/dev.ipynb
@@ -7,16 +7,11 @@
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from turbinedaq.daqtasks import AftAcsDaqThread\n",
+    "%autoreload 2\n",
+    "\n",
+    "import time\n",
+    "import pandas as pd\n",
+    "from turbinedaq.daqtasks import AftAcsDaqThread, AcsDaqThread\n",
     "from acspy import acsc\n",
     "\n",
     "hc = acsc.open_comm_simulator()"
@@ -28,36 +23,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thread = AftAcsDaqThread(acs_hc=hc, makeprg=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "thread.start()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "thread.stop()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
+    "thread = AftAcsDaqThread(acs_hc=hc, makeprg=True, sample_rate=1000, bufflen=500)\n",
+    "thread.start()\n",
+    "time.sleep(2)\n",
+    "thread.stop()\n",
     "pd.DataFrame(thread.data).time.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread = AcsDaqThread(acs_hc=hc, makeprg=True, sample_rate=1000, bufflen=500)\n",
+    "thread.start()\n",
+    "time.sleep(5)\n",
+    "thread.stop()\n",
+    "pd.DataFrame(thread.data).time.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread.dblen // 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(thread.prg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread.sr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread.sleeptime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread.dblen"
    ]
   },
   {

--- a/dev.ipynb
+++ b/dev.ipynb
@@ -19,7 +19,7 @@
     "from turbinedaq.daqtasks import AftAcsDaqThread\n",
     "from acspy import acsc\n",
     "\n",
-    "hc = acsc.open_comm_ethernet_tcp()"
+    "hc = acsc.open_comm_simulator()"
    ]
   },
   {
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thread = AftAcsDaqThread(acs_hc=hc, sample_rate=500, makeprg=True)"
+    "thread = AftAcsDaqThread(acs_hc=hc, makeprg=True)"
    ]
   },
   {
@@ -46,9 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "\n",
-    "pd.DataFrame(thread.data).load_cell_ch1.plot()"
+    "thread.stop()"
    ]
   },
   {
@@ -57,7 +55,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thread.stop()"
+    "import pandas as pd\n",
+    "\n",
+    "pd.DataFrame(thread.data).time.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "np.all(np.diff(thread.data[\"time\"]) == 0.001)"
    ]
   },
   {

--- a/turbinedaq/daqtasks.py
+++ b/turbinedaq/daqtasks.py
@@ -302,8 +302,8 @@ class AcsDaqThread(QtCore.QThread):
         }
         self.dblen = bufflen
         self.sr = sample_rate
-        # Compute sleep time as slightly longer than the time it would take to
-        # fill half of the data buffer
+        # Compute sleep time as slightly less than the time it would take to
+        # fill the data buffer
         self.sleeptime = float(self.dblen) / float(self.sr) * 0.9
         self.makeprg = makeprg
 

--- a/turbinedaq/tests/test_daqtasks.py
+++ b/turbinedaq/tests/test_daqtasks.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from acspy import acsc
 
-from turbinedaq.daqtasks import AftAcsDaqThread
+from turbinedaq.daqtasks import AcsDaqThread, AftAcsDaqThread
 
 
 @pytest.fixture
@@ -18,6 +18,14 @@ def acs_hcomm():
 
 def test_aftacsdaqthread(acs_hcomm):
     thread = AftAcsDaqThread(acs_hc=acs_hcomm, makeprg=True)
+    thread.start()
+    time.sleep(2)
+    thread.stop()
+    assert np.all(np.diff(thread.data["time"] == 0.001))
+
+
+def test_acsdaqthread(acs_hcomm):
+    thread = AcsDaqThread(acs_hc=acs_hcomm, makeprg=True)
     thread.start()
     time.sleep(2)
     thread.stop()

--- a/turbinedaq/tests/test_daqtasks.py
+++ b/turbinedaq/tests/test_daqtasks.py
@@ -1,0 +1,24 @@
+"""Tests for the ``daqtasks`` module."""
+
+import time
+
+import numpy as np
+import pytest
+from acspy import acsc
+
+from turbinedaq.daqtasks import AftAcsDaqThread
+
+
+@pytest.fixture
+def acs_hcomm():
+    hc = acsc.open_comm_simulator()
+    yield hc
+    acsc.closeComm(hc)
+
+
+def test_aftacsdaqthread(acs_hcomm):
+    thread = AftAcsDaqThread(acs_hc=acs_hcomm, makeprg=True)
+    thread.start()
+    time.sleep(2)
+    thread.stop()
+    assert np.all(np.diff(thread.data["time"] == 0.001))

--- a/turbinedaq/tests/test_daqtasks.py
+++ b/turbinedaq/tests/test_daqtasks.py
@@ -21,7 +21,7 @@ def test_aftacsdaqthread(acs_hcomm):
     thread.start()
     time.sleep(2)
     thread.stop()
-    assert np.all(np.diff(thread.data["time"] == 0.001))
+    assert np.all(np.round(np.diff(thread.data["time"]), decimals=6) == 0.001)
 
 
 def test_acsdaqthread(acs_hcomm):
@@ -29,4 +29,4 @@ def test_acsdaqthread(acs_hcomm):
     thread.start()
     time.sleep(2)
     thread.stop()
-    assert np.all(np.diff(thread.data["time"] == 0.001))
+    assert np.all(np.round(np.diff(thread.data["time"]), decimals=6) == 0.001)


### PR DESCRIPTION
Instead of trying to sleep the right amount, this change will make the app read the entire buffer, drop duplicates, and sort by time before appending. Added some unit tests for this and it's working pretty solidly.

Resolves #93 

Sample data collection from the dev notebook using the ACS simulator:

<img width="763" alt="image" src="https://github.com/petebachant/TurbineDAQ/assets/4604869/3ddd16eb-32b2-454d-882e-d136d0f9a260">
